### PR TITLE
fix: Don’t break on Node 5 or 7

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -17,8 +17,10 @@ function getDefaultVersion () {
   const nodeMajor = require('semver').major(process.version)
   switch (nodeMajor) {
     case 4:
+    case 5:
       return 'latest-1'
     case 6:
+    case 7:
       return 'latest-2'
     default:
       if (nodeMajor < 4) throw new Error('pnpm requires at least Node.js v4')


### PR DESCRIPTION
This prevents the script from causing odd failures on Node 5 or 7.

---

Yes, I know that Node 5 and 7 are long unsupported, but this at least ensures that this script isn’t the cause of odd issues in those environments.